### PR TITLE
added support for PreparedQuery, which bypasses come of Sitecore's query...

### DIFF
--- a/scSearchContrib.Searcher/QueryRunner.cs
+++ b/scSearchContrib.Searcher/QueryRunner.cs
@@ -21,6 +21,18 @@ namespace scSearchContrib.Searcher
         public QueryRunner(string indexId)
         {
             Index = SearchManager.GetIndex(indexId);
+            UsePreparedQuery = false;
+        }
+
+        /// <summary>
+        /// Allows use of a PreparedQuery, which bypasses some of Sitecore.Search's query rewriting and prevents it from translating Term queries into Prefix queries.
+        /// </summary>
+        /// <param name="indexId"></param>
+        /// <param name="usePreparedQuery"></param>
+        public QueryRunner(string indexId, bool usePreparedQuery)
+        {
+            Index = SearchManager.GetIndex(indexId);
+            UsePreparedQuery = usePreparedQuery;
         }
 
         #endregion ctor
@@ -28,6 +40,8 @@ namespace scSearchContrib.Searcher
         #region Properties
 
         public Index Index { get; set; }
+
+        public bool UsePreparedQuery { get; set; }
 
         #endregion Properties
 
@@ -53,7 +67,14 @@ namespace scSearchContrib.Searcher
                     }
                     else
                     {
-                        searchhits = context.Search(query);
+                        if (UsePreparedQuery)
+                        {
+                            searchhits = context.Search(new PreparedQuery(query));
+                        }
+                        else
+                        {
+                            searchhits = context.Search(query);
+                        }
                     }
 
                     if (searchhits == null) return null;


### PR DESCRIPTION
... rewriting. i.e. allows you to actually use a TermQuery and not have it changed against your will to a PrefixQuery.
