### PR TITLE
Fix SearchHits.FetchResults second parameter (end vs count)

### DIFF
--- a/scSearchContrib.Searcher/QueryRunner.cs
+++ b/scSearchContrib.Searcher/QueryRunner.cs
@@ -63,7 +63,7 @@ namespace scSearchContrib.Searcher
                     }
                     totalResults = searchhits.Length;
                     if (end == 0 || end > searchhits.Length) end = totalResults;
-                    var resultCollection = searchhits.FetchResults(start, end);
+                    var resultCollection = searchhits.FetchResults(start, end - start);
                     SearchHelper.GetItemsFromSearchResult(resultCollection, items, showAllVersions);
                 }
             }


### PR DESCRIPTION
When retrieving paged search results, any page other than the first and last will return more items than it should. 

For example, a search resulting in 50 items, page size 10 would go like this:
  Page 1 (start=0, end=10) => items 1-10 (ok)
  Page 2 (start=10, end=20) => items 10-30 (wrong)
  Page 3 (start=20, end=30) => items 20-50 (wrong)
  Page 4 (start=30, end=40) => items 30-50 (wrong)
  Page 5 (start=40, end=50) => items 40-50 (ok)
