### PR TITLE
fixed nullexception when item is not accessible due to security

### DIFF
--- a/scSearchContrib.Searcher/SkinnyItem.cs
+++ b/scSearchContrib.Searcher/SkinnyItem.cs
@@ -181,7 +181,7 @@
             var versionItem = db.GetItem(this.Uri.ToDataUri());
 
             // handling edge case when an item was published but not updated in the index
-            if (versionItem.Fields.Count > 0)
+            if (versionItem != null && versionItem.Fields.Count > 0)
             {
                 return versionItem;
             }


### PR DESCRIPTION
When an item is placed under security the getitem will return null, causing the check on the fields to cause a nullreferenceexception. Checking for null on versionItem resolves this issue.
