### PR TITLE
Changed Refinements/Ranges to IEnumerables

### DIFF
--- a/scSearchContrib.Searcher/Parameters/DateRangeSearchParam.cs
+++ b/scSearchContrib.Searcher/Parameters/DateRangeSearchParam.cs
@@ -37,7 +37,7 @@
             #endregion Properties
         }
 
-        public List<DateRange> Ranges { get; set; }
+        public IEnumerable<DateRange> Ranges { get; set; }
 
         protected override Query BuildQuery(BooleanClause.Occur condition)
         {

--- a/scSearchContrib.Searcher/Parameters/MultiFieldSearchParam.cs
+++ b/scSearchContrib.Searcher/Parameters/MultiFieldSearchParam.cs
@@ -20,7 +20,7 @@
             Refinements = new List<Refinement>();
         }
 
-        public List<Refinement> Refinements { get; set; }
+        public IEnumerable<Refinement> Refinements { get; set; }
 
         protected override Query BuildQuery(BooleanClause.Occur innerCondition)
         {

--- a/scSearchContrib.Searcher/Parameters/NumericRangeSearchParam.cs
+++ b/scSearchContrib.Searcher/Parameters/NumericRangeSearchParam.cs
@@ -37,7 +37,7 @@
             #endregion Properties
         }
 
-        public List<NumericRangeField> Ranges { get; set; }
+        public IEnumerable<NumericRangeField> Ranges { get; set; }
 
         protected override Query BuildQuery(BooleanClause.Occur condition)
         {

--- a/scSearchContrib.Searcher/QueryBuilder.cs
+++ b/scSearchContrib.Searcher/QueryBuilder.cs
@@ -99,7 +99,7 @@
             return new TermQuery(new Term(fieldName.ToLowerInvariant(), fieldValue));
         }
 
-        public static Query BuildNumericRangeSearchParam(List<NumericRangeSearchParam.NumericRangeField> ranges, BooleanClause.Occur condition)
+        public static Query BuildNumericRangeSearchParam(IEnumerable<NumericRangeSearchParam.NumericRangeField> ranges, BooleanClause.Occur condition)
         {
             Assert.ArgumentNotNull(ranges, "Ranges");
 
@@ -108,9 +108,9 @@
                 return null;
             }
 
-            if (ranges.Count == 1)
+            if (ranges.Count() == 1)
             {
-                return BuildNumericRangeQuery(ranges[0]);
+                return BuildNumericRangeQuery(ranges.First());
             }
 
             var innerQuery = new BooleanQuery();
@@ -122,7 +122,7 @@
             return innerQuery;
         }
 
-        public static Query BuildDateRangeSearchParam(List<DateRangeSearchParam.DateRange> ranges, BooleanClause.Occur condition)
+        public static Query BuildDateRangeSearchParam(IEnumerable<DateRangeSearchParam.DateRange> ranges, BooleanClause.Occur condition)
         {
             Assert.ArgumentNotNull(ranges, "Ranges");
 
@@ -131,9 +131,9 @@
                 return null;
             }
 
-            if (ranges.Count == 1)
+            if (ranges.Count() == 1)
             {
-                return BuildDateRangeQuery(ranges[0]);
+                return BuildDateRangeQuery(ranges.First());
             }
 
             var innerQuery = new BooleanQuery();
@@ -192,7 +192,7 @@
             return new RangeQuery(startTerm, endTerm, true);
         }
 
-        public static Query BuildMultiFieldQuery(List<MultiFieldSearchParam.Refinement> refinements, BooleanClause.Occur condition)
+        public static Query BuildMultiFieldQuery(IEnumerable<MultiFieldSearchParam.Refinement> refinements, BooleanClause.Occur condition)
         {
             Assert.ArgumentNotNull(refinements, "Refinements");
 
@@ -201,9 +201,9 @@
                 return null;
             }
 
-            if (refinements.Count == 1)
+            if (refinements.Count() == 1)
             {
-                return BuildFieldQuery(refinements[0].Name, refinements[0].Value);
+                return BuildFieldQuery(refinements.First().Name, refinements.First().Value);
             }
 
             var innerQuery = new BooleanQuery();


### PR DESCRIPTION
Changing to IEnumerables reduces some superfluous method calls to create
the refinements/ranges.

For example

```
keywords.Select(x => x.ID.ToString())
```

instead of

```
keywords.Select(x => x.ID.ToString()).ToList()
```
